### PR TITLE
Renames the quickfix-related builtin variables from lsp references

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -187,18 +187,18 @@ builtin.quickfix = function()
     return
   end
 
-  local lsp_reference_finder = finders.new {
+  local quickfix_finder = finders.new {
     results = results
   }
 
-  local reference_previewer = previewers.qflist
-  local reference_picker = pickers.new {
-    previewer = reference_previewer
+  local quickfix_previewer = previewers.qflist
+  local quickfix_picker = pickers.new {
+    previewer = quickfix_previewer
   }
 
-  reference_picker:find {
-    prompt = 'LSP References',
-    finder = lsp_reference_finder,
+  quickfix_picker:find {
+    prompt = 'Quickfix',
+    finder = quickfix_finder,
     sorter = sorters.get_norcalli_sorter(),
   }
 end


### PR DESCRIPTION
Prior to this commit, there looks to have been some missed renames and cleanup for variables for the `quickfix` builtin function. Was referencing the `LSP Reference` builtin variables and labels.