### PR TITLE
Tweak vertical layout

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -97,7 +97,7 @@ layout_strategies.vertical = function(self, max_columns, max_lines, prompt_title
   local results = initial_options.results
   local prompt = initial_options.prompt
 
-  local width_padding = math.ceil((1 - self.window.width) * 0.5 * max_columns)
+  local width_padding = 3
   local width = max_columns - width_padding * 2
   if not self.previewer then
     preview.width = 0
@@ -110,12 +110,12 @@ layout_strategies.vertical = function(self, max_columns, max_lines, prompt_title
   -- Height
   local height_padding = 3
 
-  results.height = 10
   prompt.height = 1
 
-  -- The last 2 * 2 is for the extra borders
+  -- Plus 2 * 2 for the extra borders
   if self.previewer then
-    preview.height = max_lines - results.height - prompt.height - 2 * 2 - height_padding * 2
+    preview.height = math.ceil(0.5 * max_lines - 4)
+    results.height = max_lines - preview.height - prompt.height - 2 * 3 - height_padding * 2
   else
     results.height = max_lines - prompt.height - 2 - height_padding * 2
   end


### PR DESCRIPTION
This is a slight tweak to the vertical layout strategy (useful for "thin" windows) with the following changes:
1. Instead of a percentage of neovim window width, make the telescope windows full width with a two column border.
2. Instead of fixing the size of the results window, fix the size of the preview window to half neovim window height and adjust the remaining windows to fit.
3. Leave two rows of space after the prompt window (to mirror the two windows of space before the preview window).

I feel this "50% vertical split" strategy is more visually pleasant and fits better with the default "50% horizontal split" strategy.
<img width="979" alt="Screenshot 2020-09-08 at 18 28 59" src="https://user-images.githubusercontent.com/2361214/92503170-2a7dd480-f201-11ea-8e29-88527ccb094b.png">
