### PR TITLE
feat: add scrolling in preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ j      k     next | previous (in normal mode)
 <C-v>        go to file selection as a vertical split
 <C-t>        go to a file in a new tab
 
+<C-u>        scroll up in preview window
+<C-d>        scroll down in preview window
+
 <C-c>        close telescope
 <Esc>        close telescope (in normal mode)
 ```

--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -34,13 +34,6 @@ function actions.get_selected_entry(prompt_bufnr)
   return actions.get_current_picker(prompt_bufnr):get_selection()
 end
 
-local function preview_scrolling(prompt_bufnr, termcode)
-  local preview_win = state.get_status(prompt_bufnr).preview_win
-  local bufnr = vim.api.nvim_win_get_buf(preview_win)
-  local channel = vim.api.nvim_buf_get_option(bufnr, "channel")
-  vim.fn.chansend(channel, termcode)
-end
-
 function actions.preview_scrolling_up(prompt_bufnr)
   actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(-1)
 end

--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -34,6 +34,21 @@ function actions.get_selected_entry(prompt_bufnr)
   return actions.get_current_picker(prompt_bufnr):get_selection()
 end
 
+local function preview_scrolling(prompt_bufnr, termcode)
+  local preview_win = state.get_status(prompt_bufnr).preview_win
+  local bufnr = vim.api.nvim_win_get_buf(preview_win)
+  local channel = vim.api.nvim_buf_get_option(bufnr, "channel")
+  vim.fn.chansend(channel, termcode)
+end
+
+function actions.preview_scrolling_up(prompt_bufnr)
+  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(-1)
+end
+
+function actions.preview_scrolling_down(prompt_bufnr)
+  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(1)
+end
+
 -- TODO: It seems sometimes we get bad styling.
 local function goto_file_selection(prompt_bufnr, command)
   local picker = actions.get_current_picker(prompt_bufnr)

--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -35,11 +35,11 @@ function actions.get_selected_entry(prompt_bufnr)
 end
 
 function actions.preview_scrolling_up(prompt_bufnr)
-  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(-1)
+  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(-30)
 end
 
 function actions.preview_scrolling_down(prompt_bufnr)
-  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(1)
+  actions.get_current_picker(prompt_bufnr).previewer:scroll_fn(30)
 end
 
 -- TODO: It seems sometimes we get bad styling.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -42,6 +42,9 @@ local default_mappings = {
     ["<C-x>"] = actions.goto_file_selection_split,
     ["<C-v>"] = actions.goto_file_selection_vsplit,
     ["<C-t>"] = actions.goto_file_selection_tabedit,
+
+    ["<C-u>"] = actions.preview_scrolling_up,
+    ["<C-d>"] = actions.preview_scrolling_down,
   },
 
   n = {
@@ -57,6 +60,9 @@ local default_mappings = {
 
     ["<Down>"] = actions.move_selection_next,
     ["<Up>"] = actions.move_selection_previous,
+
+    ["<C-u>"] = actions.preview_scrolling_up,
+    ["<C-d>"] = actions.preview_scrolling_down,
   },
 }
 

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -11,7 +11,7 @@ local Previewer = {}
 Previewer.__index = Previewer
 
 -- TODO: Should play with these some more, ty @clason
-local bat_options = " --style=plain --paging=never --color=always "
+local bat_options = " --style=plain --color=always "
 
 local previewer_ns = vim.api.nvim_create_namespace('telescope.previewers')
 
@@ -28,6 +28,8 @@ function Previewer:new(opts)
     state = nil,
     _setup_func = opts.setup,
     _teardown_func = opts.teardown,
+    _send_input = opts.send_input,
+    _scroll_fn = opts.scroll_fn,
     preview_fn = opts.preview_fn,
   }, Previewer)
 end
@@ -52,6 +54,18 @@ end
 function Previewer:teardown()
   if self._teardown_func then
     self:_teardown_func()
+  end
+end
+
+function Previewer:send_input(input)
+  if self._send_input then
+    self:_send_input(input)
+  end
+end
+
+function Previewer:scroll_fn(direction)
+  if self._scroll_fn then
+    self:_scroll_fn(direction)
   end
 end
 
@@ -184,6 +198,21 @@ previewers.cat = defaulter(function(opts)
         command_string = command_string,
         termopen_id = nil,
       }
+    end,
+
+    send_input = function(self, input)
+      termcode = vim.api.nvim_replace_termcodes(input, true, false, true)
+      if self.state.termopen_id then
+        pcall(vim.fn.chansend, self.state.termopen_id, termcode)
+      end
+    end,
+
+    scroll_fn = function(self, direction)
+      if not self.state then
+        return
+      end
+      if direction > 0 then input = "<c-d>" else input = "<c-u>" end
+      self:send_input(input)
     end,
 
     teardown = function(self)

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -60,12 +60,16 @@ end
 function Previewer:send_input(input)
   if self._send_input then
     self:_send_input(input)
+  else
+    vim.api.nvim_err_writeln("send_input is not defined for this previewer")
   end
 end
 
 function Previewer:scroll_fn(direction)
   if self._scroll_fn then
     self:_scroll_fn(direction)
+  else
+    vim.api.nvim_err_writeln("scroll_fn is not defined for this previewer")
   end
 end
 

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -215,8 +215,9 @@ previewers.cat = defaulter(function(opts)
       if not self.state then
         return
       end
-      if direction > 0 then input = "<c-d>" else input = "<c-u>" end
-      self:send_input(input)
+      if direction > 0 then input = "d" else input = "u" end
+      local count = math.abs(direction)
+      self:send_input(count..input)
     end,
 
     teardown = function(self)


### PR DESCRIPTION
This PR tries to add a member function `scroll_fn` to Previewer. For previewer like `bat` you can use `chansend` to send termcodes of `<c-u>` or `<c-d>` to scrolling. For now this only works for `bat` but similar things should be able to port to vim buffer or other previewer.

Todo:
- [x] add docs for mappings.
- [ ] add `scroll_fn` for vim buffer(maybe in another PR?)