### PR TITLE
Restrict builtin find_files to files

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -339,7 +339,7 @@ builtin.find_files = function(opts)
   pickers.new(opts, {
     prompt = 'Find Files',
     finder = finders.new_oneshot_job(
-      {fd_string},
+      {fd_string, '--type', 'f'},
       opts
     ),
     previewer = previewers.cat.new(opts),


### PR DESCRIPTION
Add `--type f` to `fd`/`fdfind` in `builtin.find_files` to only return actual files (and not directories, which the previewer can't handle anyway)