### PR TITLE
Add smart case to vimgrep arguments

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -46,7 +46,7 @@ function config.set_defaults(defaults)
 
   -- List that will be executed.
   --    Last argument will be the search term (passed in during execution)
-  set("vimgrep_arguments", {'rg', '--color=never', '--no-heading', '--with-filename', '--line-number', '--column'})
+  set("vimgrep_arguments", {'rg', '--color=never', '--no-heading', '--with-filename', '--line-number', '--column', '--smart-case'})
 
   -- TODO: Shortenpath
   --    Decide how to propagate that to all the opts everywhere.


### PR DESCRIPTION
Meaning case insensitive unless query contains upper case.