### PR TITLE
Add sorter to live_grep

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -76,6 +76,7 @@ builtin.live_grep = function(opts)
     prompt    = 'Live Grep',
     finder    = live_grepper,
     previewer = previewers.vimgrep.new(opts),
+    sorter    = sorters.get_generic_fuzzy_sorter(),
   }):find()
 end
 


### PR DESCRIPTION
Even if the matching is exact, the sorting is still helpful when multiple results are found.