### PR TITLE
feat: Add dropdown layout strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Support for:
 * LSP (references, document symbols, workspace symbols)
 * Treesitter
 * Grep
-* Files (git, fd)
+* Files (git, fd, rg)
 * Vim (command history, quickfix, loclist)
 
 [What is Telescope?](https://www.twitch.tv/teej_dv/clip/RichDistinctPlumberPastaThat)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Handy documentation, showcase of all tools available in Telescope.
 require'telescope.builtin'.git_files{}
 ```
 
-Search your files in a git repo. Ignores files in your .gitignore.
+Search your files in a git repo. Ignores files in your .gitignore. You can optionally override the find command.
 
 Note: Requires the `cwd` to be a git directory.
 
@@ -186,6 +186,7 @@ Note: Requires the `cwd` to be a git directory.
 require'telescope.builtin'.find_files{
   -- Optional
   -- cwd = "/home/tj/"
+  -- find_command = { "rg", "-i", "--hidden", "--files", "-g", "!.git" }
 }
 ```
 Searches files in your working directory.

--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -366,13 +366,16 @@ end
 builtin.find_files = function(opts)
   opts = opts or {}
 
-  local find_command = nil
-  if 1 == vim.fn.executable("fd") then
-    find_command = { 'fd', '--type', 'f' }
-  elseif 1 == vim.fn.executable("fdfind") then
-    find_command = { 'fdfind', '--type', 'f' }
-  elseif 1 == vim.fn.executable("rg") then
-    find_command = { 'rg', '--files' }
+  local find_command = opts.find_command
+
+  if not find_command then
+    if 1 == vim.fn.executable("fd") then
+      find_command = { 'fd', '--type', 'f' }
+    elseif 1 == vim.fn.executable("fdfind") then
+      find_command = { 'fdfind', '--type', 'f' }
+    elseif 1 == vim.fn.executable("rg") then
+      find_command = { 'rg', '--files' }
+    end
   end
 
   if not find_command then

--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -366,15 +366,17 @@ end
 builtin.find_files = function(opts)
   opts = opts or {}
 
-  local fd_string = nil
+  local find_command = nil
   if 1 == vim.fn.executable("fd") then
-    fd_string = "fd"
+    find_command = { 'fd', '--type', 'f' }
   elseif 1 == vim.fn.executable("fdfind") then
-    fd_string = "fdfind"
+    find_command = { 'fdfind', '--type', 'f' }
+  elseif 1 == vim.fn.executable("rg") then
+    find_command = { 'rg', '--files' }
   end
 
-  if not fd_string then
-    print("You need to install fd or submit PR for different default file finder :)")
+  if not find_command then
+    print("You need to install either fd or rg. You can also submit a PR to add support for another file finder :)")
     return
   end
 
@@ -387,7 +389,7 @@ builtin.find_files = function(opts)
   pickers.new(opts, {
     prompt = 'Find Files',
     finder = finders.new_oneshot_job(
-      {fd_string, '--type', 'f'},
+      find_command,
       opts
     ),
     previewer = previewers.cat.new(opts),

--- a/lua/telescope/config/resolve.lua
+++ b/lua/telescope/config/resolve.lua
@@ -87,21 +87,41 @@ local get_default = require('telescope.utils').get_default
 
 local resolver = {}
 
-local percentage_resolver = function(selector, percentage)
-  assert(percentage <= 1)
-  assert(percentage >= 0)
+local _resolve_map = {
+  -- Percentages
+  [function(val) return type(val) == 'number' and val > 0 and val <= 1 end] = function(selector, val)
+    return function(...)
+      return math.floor(val * select(selector, ...))
+    end
+  end,
 
-  return function(...)
-    return percentage * select(selector, ...)
+  -- Numbers
+  [function(val) return type(val) == 'number' and val > 1 end] = function(selector, val)
+    return function(...)
+      return math.min(val, select(selector, ...))
+    end
+  end,
+
+}
+
+resolver.resolve_height = function(val)
+  for k, v in pairs(_resolve_map) do
+    if k(val) then
+      return v(3, val)
+    end
   end
+
+  error('invalid configuration option for height:' .. tostring(val))
 end
 
-resolver.resolve_percentage_height = function(percentage)
-  return percentage_resolver(3, percentage)
-end
+resolver.resolve_width = function(val)
+  for k, v in pairs(_resolve_map) do
+    if k(val) then
+      return v(2, val)
+    end
+  end
 
-resolver.resolve_percentage_width = function(percentage)
-  return percentage_resolver(2, percentage)
+  error('invalid configuration option for height:' .. tostring(val))
 end
 
 --- Win option always returns a table with preview, results, and prompt.

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -83,7 +83,9 @@ function Picker:new(opts)
 
   return setmetatable({
     prompt = opts.prompt,
-    default_text = opts.default_text,
+		results_title = opts.results_title,
+		preview_title = opts.preview_title,
+		default_text = opts.default_text,
 
     finder = opts.finder,
     sorter = opts.sorter,
@@ -139,7 +141,7 @@ function Picker:_get_initial_window_options(prompt_title)
   local popup_borderchars = resolve.win_option(self.window.borderchars)
 
   local preview = {
-    title = 'Preview',
+    title = self.preview_title or 'Preview',
     border = popup_border.preview,
     borderchars = popup_borderchars.preview,
     enter = false,
@@ -147,7 +149,7 @@ function Picker:_get_initial_window_options(prompt_title)
   }
 
   local results = {
-    title = 'Results',
+    title = self.results_title or 'Results',
     border = popup_border.results,
     borderchars = popup_borderchars.results,
     enter = false,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -83,9 +83,9 @@ function Picker:new(opts)
 
   return setmetatable({
     prompt = opts.prompt,
-		results_title = opts.results_title,
-		preview_title = opts.preview_title,
-		default_text = opts.default_text,
+    results_title = opts.results_title,
+    preview_title = opts.preview_title,
+    default_text = opts.default_text,
 
     finder = opts.finder,
     sorter = opts.sorter,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -290,7 +290,6 @@ function Picker:find()
   a.nvim_win_set_option(prompt_win, 'winblend', self.window.winblend)
 
   a.nvim_win_set_option(prompt_win, 'winhl', 'Normal:TelescopeNormal')
-  pcall(a.nvim_buf_set_option, prompt_bufnr, 'filetype', 'TelescopePrompt')
 
   -- a.nvim_buf_set_option(prompt_bufnr, 'buftype', 'prompt')
   -- vim.fn.prompt_setprompt(prompt_bufnr, prompt_string)
@@ -313,6 +312,7 @@ function Picker:find()
     local displayed_amount = 0
     local displayed_fn_amount = 0
 
+    -- TODO: Entry manager should have a "bulk" setter. This can prevent a lot of redraws from display
     self.manager = pickers.entry_manager(
       self.max_results,
       vim.schedule_wrap(function(index, entry)
@@ -472,6 +472,9 @@ function Picker:find()
   })
 
   mappings.apply_keymap(prompt_bufnr, self.attach_mappings, default_mappings)
+
+  -- Do filetype last, so that users can register at the last second.
+  pcall(a.nvim_buf_set_option, prompt_bufnr, 'filetype', 'TelescopePrompt')
 
   if self.default_text then
     vim.api.nvim_buf_set_lines(prompt_bufnr, 0, 1, false, {self.default_text})

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,29 +1,31 @@
 --[[
-    Layout strategies are different functions to position telescope.
 
-    horizontal: 
-    - Supports `prompt_position`, `preview_cutoff`
+Layout strategies are different functions to position telescope.
 
-    vertical:
+horizontal:
+- Supports `prompt_position`, `preview_cutoff`
 
-    flex: Swap between `horizontal` and `vertical` strategies based on the window width
-    - Supports `vertical` or `horizontal` features 
+vertical:
 
-    dropdown:
+flex: Swap between `horizontal` and `vertical` strategies based on the window width
+- Supports `vertical` or `horizontal` features
+
+dropdown:
 
 
-   Layout strategies are callback functions
+Layout strategies are callback functions
 
-   -- @param self: Picker
-   -- @param columns: number Columns in the vim window
-   -- @param lines: number Lines in the vim window
-   -- @param prompt_title: string
-   function(self, columns, lines, prompt_title)
-   end
+-- @param self: Picker
+-- @param columns: number Columns in the vim window
+-- @param lines: number Lines in the vim window
+-- @param prompt_title: string
+function(self, columns, lines, prompt_title)
+end
+
 --]]
 local layout_strategies = {}
 local log = require('telescope.log')
-
+local resolve = require('telescope.config.resolve')
 --[[
    +-----------------+---------------------+
    |                 |                     |
@@ -117,35 +119,14 @@ end
     +-----------------+
 --]]
 
--- TODO(rockerBOO): Move these generics to some library?
-local is_all = function(array, comparable)
-   if array == nil then return false end
-
-  for n in array 
-  do
-    if n ~= comparable then return false end
-  end
-  
-  return true
-end
-
--- Check if all items in an array are empty strings
-local is_all_empty_strings = function(array)
-  return is_all(array, "") 
-end
-
--- Check if there are any borders. Right now it's a little raw as 
--- there are a few things that contribute to the border 
+-- Check if there are any borders. Right now it's a little raw as
+-- there are a few things that contribute to the border
 local is_borderless = function(opts)
-  -- Note: borderchars is not a great check here, we need some boolean for borders 
-  -- or other border options. For instance to add a border only around the outside.
-  -- A border around the outside may have different side effects.
-  return opts.results_title == "" and is_all_empty_strings(opts.borderchars)
+  if opts.window.border == false then return true end
 end
 
 layout_strategies.dropdown = function(self, columns, lines, prompt_title)
   local initial_options = self:_get_initial_window_options(prompt_title)
-
   local preview = initial_options.preview
   local results = initial_options.results
   local prompt = initial_options.prompt
@@ -153,8 +134,8 @@ layout_strategies.dropdown = function(self, columns, lines, prompt_title)
   local max_results = self.max_results or 15
   local width = self.window.width or 80
 
-  -- consider width of the window
-  local max_width = width 
+  --TODO(rockerBOO): consider width of the window
+  local max_width = width
 
   prompt.height = 1
   results.height = max_results
@@ -164,11 +145,10 @@ layout_strategies.dropdown = function(self, columns, lines, prompt_title)
 
   if is_borderless(self) then
     prompt.line = lines / 2 - (( max_results + 1) / 2 )
-    results.line = prompt.line + 3 
+    results.line = prompt.line + 1 
   else
     prompt.line = lines / 2 - (( max_results + 1 + 2 + 2 )/ 2 )
-    results.line = prompt.line + 1
-
+    results.line = prompt.line + 3 
   end
 
   prompt.col =  (columns / 2) - (width/ 2)

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,6 +1,6 @@
 
 local layout_strategies = {}
-
+local log = require('telescope.log')
 --[[
    +-----------------+---------------------+
    |                 |                     |
@@ -11,6 +11,15 @@ local layout_strategies = {}
    |     Prompt      |                     |
    +-----------------+---------------------+
 --]]
+
+-- Layout strategies are callback functions with this signature
+-- function(self, max_columns, max_lines, prompt_title)
+--
+-- @param max_columns: number
+-- @param max_lines: number
+-- @param prompt_title: string
+
+
 layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_title)
   local initial_options = self:_get_initial_window_options(prompt_title)
   local preview = initial_options.preview
@@ -19,7 +28,6 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
 
   -- TODO: Test with 120 width terminal
   -- TODO: Test with self.width
-
   local width_padding = 10
 
   -- TODO: Determine config settings.
@@ -40,6 +48,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
   end
 
   local other_width = max_columns - preview.width - (2 * width_padding)
+
   results.width = other_width
   prompt.width = other_width
 
@@ -84,7 +93,49 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
   }
 end
 
+--[[
+    +-----------------+
+    |     Prompt      |
+    +-----------------+
+    |     Result      |
+    |     Result      |
+    |     Result      |
+    +-----------------+
+--]]
 
+layout_strategies.dropdown = function(self, columns, lines, prompt_title)
+	local initial_options = self:_get_initial_window_options(prompt_title)
+
+	local preview = initial_options.preview
+	local results = initial_options.results
+	local prompt = initial_options.prompt
+
+	local max_results = self.max_results or 15
+	local width = self.window.width or 80
+
+	prompt.height = 1
+	results.height = max_results
+
+	prompt.width = width
+	results.width = width
+
+	prompt.line = lines / 2 - (( 15 + 1 + 2 + 2)/2)
+
+	if self.results_title ~= "" then
+		results.line = prompt.line + 3
+	else
+		results.line = prompt.line + 1
+	end
+
+	prompt.col =  (columns / 2) - (width/ 2)
+	results.col = (columns / 2) - (width/ 2)
+
+	return {
+		preview = preview,
+		results = results,
+		prompt = prompt
+	}
+end
 
 --[[
     +-----------------+

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -1,0 +1,57 @@
+-- Prototype Theme System
+-- Currently certain designs need a number of parameters.
+--
+-- local opts = GetTheme("dropdown", { winblend = 3 })
+-- 
+
+local Theme = {}
+Theme.__index = Theme
+
+local merge = function(table1, table2)
+  for k, v in pairs(table2) do table1[k] = v end
+
+  return table1
+end
+
+function Theme:new(opts)
+  opts = opts or {}
+
+  return setmetatable({
+    layout_strategy = opts.layout_strategy,
+    border = opts.border,
+    sorting_strategy = opts.sorting_strategy,
+    prompt = opts.prompt,
+    results_title = opts.results_title,
+    preview_title = opts.preview_title,
+    borderchars = opts.borderchars,
+  }, Theme)
+end
+
+function Theme:get_opts()
+  return self
+end
+
+-- Get the opts from the theme
+-- This will be defaults the theme will use to make the
+-- layout.
+local get_opts = function(theme)
+  return {
+    sorting_strategy = "ascending",
+    layout_strategy = "center",
+    border = false,
+    results_title = "",
+    preview_title = "Preview",
+    prompt = "",
+    borderchars = {"", "", "", "", "", "", "", ""},
+  }
+end
+
+function GetTheme(theme_name, opts)
+  local theme_opts = get_opts(theme_name)
+
+  local theme = Theme:new(merge(theme_opts, opts))
+
+  return theme
+end
+
+return Theme

--- a/lua/tests/manual/resolver_spec.lua
+++ b/lua/tests/manual/resolver_spec.lua
@@ -49,6 +49,13 @@ eq('a', opt.preview)
 eq('b', opt.prompt)
 eq('c', opt.results)
 
+
+eq(10, resolve.resolve_height(0.1)(nil, 24, 100))
+eq(2, resolve.resolve_width(0.1)(nil, 24, 100))
+
+eq(10, resolve.resolve_width(10)(nil, 24, 100))
+eq(24, resolve.resolve_width(50)(nil, 24, 100))
+
 -- local true_table = {true}
 -- opt = resolve.win_option(some_specified, 'a')
 -- eq('a', opt.preview)


### PR DESCRIPTION
Adds a dropdown strategy.

Adds results_title and preview_title options.

```vim
nnoremap <Leader>f <cmd>:lua require'telescope.builtin'.find_files({ sorting_strategy = "ascending", preview_cutoff = 200,border = false, layout_strategy = "dropdown", prompt = "",
width = 50,winblend = 3, results_title = "", borderchars = { '', '', '', '', '', '', '', ''} })<CR>
```

https://clips.twitch.tv/ExpensiveExquisitePigeonVoHiYo