### PR TITLE
Add find_command option for find_files

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -366,13 +366,16 @@ end
 builtin.find_files = function(opts)
   opts = opts or {}
 
-  local find_command = nil
-  if 1 == vim.fn.executable("fd") then
-    find_command = { 'fd', '--type', 'f' }
-  elseif 1 == vim.fn.executable("fdfind") then
-    find_command = { 'fdfind', '--type', 'f' }
-  elseif 1 == vim.fn.executable("rg") then
-    find_command = { 'rg', '--files' }
+  local find_command = opts.find_command
+
+  if not find_command then
+    if 1 == vim.fn.executable("fd") then
+      find_command = { 'fd', '--type', 'f' }
+    elseif 1 == vim.fn.executable("fdfind") then
+      find_command = { 'fdfind', '--type', 'f' }
+    elseif 1 == vim.fn.executable("rg") then
+      find_command = { 'rg', '--files' }
+    end
   end
 
   if not find_command then


### PR DESCRIPTION
This makes it possible to use `find_files` like this

```lua
builtin.find_files {
  find_command = { "rg", "-i", "--hidden", "--files", "-g", "!.git" }
}
```

BTW why is it showing old commits in this PR? Can I somehow only have the relevant commit(16817eb) shown in the PR?