### PR TITLE
feat: Themes

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -83,7 +83,9 @@ function Picker:new(opts)
 
   return setmetatable({
     prompt = opts.prompt,
-    default_text = opts.default_text,
+		results_title = opts.results_title,
+		preview_title = opts.preview_title,
+		default_text = opts.default_text,
 
     finder = opts.finder,
     sorter = opts.sorter,
@@ -139,7 +141,7 @@ function Picker:_get_initial_window_options(prompt_title)
   local popup_borderchars = resolve.win_option(self.window.borderchars)
 
   local preview = {
-    title = 'Preview',
+    title = self.preview_title or 'Preview',
     border = popup_border.preview,
     borderchars = popup_borderchars.preview,
     enter = false,
@@ -147,7 +149,7 @@ function Picker:_get_initial_window_options(prompt_title)
   }
 
   local results = {
-    title = 'Results',
+    title = self.results_title or 'Results',
     border = popup_border.results,
     borderchars = popup_borderchars.results,
     enter = false,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -83,9 +83,9 @@ function Picker:new(opts)
 
   return setmetatable({
     prompt = opts.prompt,
-		results_title = opts.results_title,
-		preview_title = opts.preview_title,
-		default_text = opts.default_text,
+    results_title = opts.results_title,
+    preview_title = opts.preview_title,
+    default_text = opts.default_text,
 
     finder = opts.finder,
     sorter = opts.sorter,

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -83,8 +83,10 @@ function Picker:new(opts)
 
   return setmetatable({
     prompt = opts.prompt,
-    results_title = opts.results_title,
-    preview_title = opts.preview_title,
+
+    results_title = get_default(opts.results_title, "Results"),
+    preview_title = get_default(opts.preview_title, "Preview"),
+
     default_text = opts.default_text,
 
     finder = opts.finder,
@@ -141,7 +143,7 @@ function Picker:_get_initial_window_options(prompt_title)
   local popup_borderchars = resolve.win_option(self.window.borderchars)
 
   local preview = {
-    title = self.preview_title or 'Preview',
+    title = self.preview_title,
     border = popup_border.preview,
     borderchars = popup_borderchars.preview,
     enter = false,
@@ -149,7 +151,7 @@ function Picker:_get_initial_window_options(prompt_title)
   }
 
   local results = {
-    title = self.results_title or 'Results',
+    title = self.results_title,
     border = popup_border.results,
     borderchars = popup_borderchars.results,
     enter = false,

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,29 +1,31 @@
 --[[
-    Layout strategies are different functions to position telescope.
 
-    horizontal: 
-    - Supports `prompt_position`, `preview_cutoff`
+Layout strategies are different functions to position telescope.
 
-    vertical:
+horizontal:
+- Supports `prompt_position`, `preview_cutoff`
 
-    flex: Swap between `horizontal` and `vertical` strategies based on the window width
-    - Supports `vertical` or `horizontal` features 
+vertical:
 
-    dropdown:
+flex: Swap between `horizontal` and `vertical` strategies based on the window width
+- Supports `vertical` or `horizontal` features
+
+dropdown:
 
 
-   Layout strategies are callback functions
+Layout strategies are callback functions
 
-   -- @param self: Picker
-   -- @param columns: number Columns in the vim window
-   -- @param lines: number Lines in the vim window
-   -- @param prompt_title: string
-   function(self, columns, lines, prompt_title)
-   end
+-- @param self: Picker
+-- @param columns: number Columns in the vim window
+-- @param lines: number Lines in the vim window
+-- @param prompt_title: string
+function(self, columns, lines, prompt_title)
+end
+
 --]]
 local layout_strategies = {}
 local log = require('telescope.log')
-
+local resolve = require('telescope.config.resolve')
 --[[
    +-----------------+---------------------+
    |                 |                     |
@@ -117,35 +119,14 @@ end
     +-----------------+
 --]]
 
--- TODO(rockerBOO): Move these generics to some library?
-local is_all = function(array, comparable)
-   if array == nil then return false end
-
-  for n in array 
-  do
-    if n ~= comparable then return false end
-  end
-  
-  return true
-end
-
--- Check if all items in an array are empty strings
-local is_all_empty_strings = function(array)
-  return is_all(array, "") 
-end
-
--- Check if there are any borders. Right now it's a little raw as 
--- there are a few things that contribute to the border 
+-- Check if there are any borders. Right now it's a little raw as
+-- there are a few things that contribute to the border
 local is_borderless = function(opts)
-  -- Note: borderchars is not a great check here, we need some boolean for borders 
-  -- or other border options. For instance to add a border only around the outside.
-  -- A border around the outside may have different side effects.
-  return opts.results_title == "" and is_all_empty_strings(opts.borderchars)
+  if opts.window.border == false then return true end
 end
 
 layout_strategies.dropdown = function(self, columns, lines, prompt_title)
   local initial_options = self:_get_initial_window_options(prompt_title)
-
   local preview = initial_options.preview
   local results = initial_options.results
   local prompt = initial_options.prompt
@@ -153,8 +134,8 @@ layout_strategies.dropdown = function(self, columns, lines, prompt_title)
   local max_results = self.max_results or 15
   local width = self.window.width or 80
 
-  -- consider width of the window
-  local max_width = width 
+  --TODO(rockerBOO): consider width of the window
+  local max_width = width
 
   prompt.height = 1
   results.height = max_results
@@ -164,11 +145,10 @@ layout_strategies.dropdown = function(self, columns, lines, prompt_title)
 
   if is_borderless(self) then
     prompt.line = lines / 2 - (( max_results + 1) / 2 )
-    results.line = prompt.line + 3 
+    results.line = prompt.line + 1 
   else
     prompt.line = lines / 2 - (( max_results + 1 + 2 + 2 )/ 2 )
-    results.line = prompt.line + 1
-
+    results.line = prompt.line + 3 
   end
 
   prompt.col =  (columns / 2) - (width/ 2)

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -1,6 +1,6 @@
 
 local layout_strategies = {}
-
+local log = require('telescope.log')
 --[[
    +-----------------+---------------------+
    |                 |                     |
@@ -11,6 +11,15 @@ local layout_strategies = {}
    |     Prompt      |                     |
    +-----------------+---------------------+
 --]]
+
+-- Layout strategies are callback functions with this signature
+-- function(self, max_columns, max_lines, prompt_title)
+--
+-- @param max_columns: number
+-- @param max_lines: number
+-- @param prompt_title: string
+
+
 layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_title)
   local initial_options = self:_get_initial_window_options(prompt_title)
   local preview = initial_options.preview
@@ -19,7 +28,6 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
 
   -- TODO: Test with 120 width terminal
   -- TODO: Test with self.width
-
   local width_padding = 10
 
   -- TODO: Determine config settings.
@@ -40,6 +48,7 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
   end
 
   local other_width = max_columns - preview.width - (2 * width_padding)
+
   results.width = other_width
   prompt.width = other_width
 
@@ -84,7 +93,49 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
   }
 end
 
+--[[
+    +-----------------+
+    |     Prompt      |
+    +-----------------+
+    |     Result      |
+    |     Result      |
+    |     Result      |
+    +-----------------+
+--]]
 
+layout_strategies.dropdown = function(self, columns, lines, prompt_title)
+	local initial_options = self:_get_initial_window_options(prompt_title)
+
+	local preview = initial_options.preview
+	local results = initial_options.results
+	local prompt = initial_options.prompt
+
+	local max_results = self.max_results or 15
+	local width = self.window.width or 80
+
+	prompt.height = 1
+	results.height = max_results
+
+	prompt.width = width
+	results.width = width
+
+	prompt.line = lines / 2 - (( 15 + 1 + 2 + 2)/2)
+
+	if self.results_title ~= "" then
+		results.line = prompt.line + 3
+	else
+		results.line = prompt.line + 1
+	end
+
+	prompt.col =  (columns / 2) - (width/ 2)
+	results.col = (columns / 2) - (width/ 2)
+
+	return {
+		preview = preview,
+		results = results,
+		prompt = prompt
+	}
+end
 
 --[[
     +-----------------+

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -22,7 +22,9 @@ Layout strategies are callback functions
 function(self, columns, lines, prompt_title)
 end
 
---]] local layout_strategies = {}
+--]]
+
+local layout_strategies = {}
 local log = require("telescope.log")
 local resolve = require("telescope.config.resolve")
 --[[
@@ -101,7 +103,11 @@ layout_strategies.horizontal = function(self, max_columns, max_lines, prompt_tit
     error("Unknown prompt_position: " .. self.window.prompt_position)
   end
 
-  return {preview = preview.width > 0 and preview, results = results, prompt = prompt}
+  return {
+    preview = preview.width > 0 and preview,
+    results = results,
+    prompt = prompt
+}
 end
 
 --[[
@@ -157,7 +163,11 @@ layout_strategies.center = function(self, columns, lines, prompt_title)
   prompt.col = results.col
   preview.col = results.col
 
-  return {preview = preview, results = results, prompt = prompt}
+  return {
+    preview = self.previewer and preview,
+    results = results,
+    prompt = prompt
+  }
 end
 
 --[[
@@ -214,7 +224,11 @@ layout_strategies.vertical = function(self, max_columns, max_lines, prompt_title
     prompt.line = results.line + results.height + 2
   end
 
-  return {preview = preview.width > 0 and preview, results = results, prompt = prompt}
+  return {
+    preview = preview.width > 0 and preview,
+    results = results,
+    prompt = prompt
+  }
 end
 
 layout_strategies.flex = function(self, max_columns, max_lines, prompt_title)

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -1,0 +1,57 @@
+-- Prototype Theme System
+-- Currently certain designs need a number of parameters.
+--
+-- local opts = GetTheme("dropdown", { winblend = 3 })
+-- 
+
+local Theme = {}
+Theme.__index = Theme
+
+local merge = function(table1, table2)
+  for k, v in pairs(table2) do table1[k] = v end
+
+  return table1
+end
+
+function Theme:new(opts)
+  opts = opts or {}
+
+  return setmetatable({
+    layout_strategy = opts.layout_strategy,
+    border = opts.border,
+    sorting_strategy = opts.sorting_strategy,
+    prompt = opts.prompt,
+    results_title = opts.results_title,
+    preview_title = opts.preview_title,
+    borderchars = opts.borderchars,
+  }, Theme)
+end
+
+function Theme:get_opts()
+  return self
+end
+
+-- Get the opts from the theme
+-- This will be defaults the theme will use to make the
+-- layout.
+local get_opts = function(theme)
+  return {
+    sorting_strategy = "ascending",
+    layout_strategy = "center",
+    border = false,
+    results_title = "",
+    preview_title = "Preview",
+    prompt = "",
+    borderchars = {"", "", "", "", "", "", "", ""},
+  }
+end
+
+function GetTheme(theme_name, opts)
+  local theme_opts = get_opts(theme_name)
+
+  local theme = Theme:new(merge(theme_opts, opts))
+
+  return theme
+end
+
+return Theme

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -1,57 +1,29 @@
--- Prototype Theme System
+-- Prototype Theme System (WIP)
 -- Currently certain designs need a number of parameters.
 --
--- local opts = GetTheme("dropdown", { winblend = 3 })
--- 
+-- local opts = themes.get_dropdown { winblend = 3 }
+--
 
-local Theme = {}
-Theme.__index = Theme
+local themes = {}
 
-local merge = function(table1, table2)
-  for k, v in pairs(table2) do table1[k] = v end
+function themes.get_dropdown(opts)
+  local theme_opts = {
+    -- WIP: Decide on keeping these names or not.
+    theme = "dropdown",
 
-  return table1
-end
-
-function Theme:new(opts)
-  opts = opts or {}
-
-  return setmetatable({
-    layout_strategy = opts.layout_strategy,
-    border = opts.border,
-    sorting_strategy = opts.sorting_strategy,
-    prompt = opts.prompt,
-    results_title = opts.results_title,
-    preview_title = opts.preview_title,
-    borderchars = opts.borderchars,
-  }, Theme)
-end
-
-function Theme:get_opts()
-  return self
-end
-
--- Get the opts from the theme
--- This will be defaults the theme will use to make the
--- layout.
-local get_opts = function(theme)
-  return {
     sorting_strategy = "ascending",
     layout_strategy = "center",
-    border = false,
-    results_title = "",
+    results_title = false,
     preview_title = "Preview",
-    prompt = "",
-    borderchars = {"", "", "", "", "", "", "", ""},
+    border = false,
+    borderchars = {
+      prompt = {"─", "│", " ", "│", "╭", "╮", "│", "│"},
+      results = {"─", "│", "─", "│", "├", "┤", "╯", "╰"},
+      preview = {"=", "=", "", "", "", "", "", ""}
+    },
   }
+
+  return vim.tbl_deep_extend("force", theme_opts, opts)
 end
 
-function GetTheme(theme_name, opts)
-  local theme_opts = get_opts(theme_name)
-
-  local theme = Theme:new(merge(theme_opts, opts))
-
-  return theme
-end
-
-return Theme
+return themes


### PR DESCRIPTION
Add a starting point with themes. 
Add center layout strategy.

Would like to finalize down the theme API but this is a good start I think.

I think you'd normally just set your theme in your opts table.

`require'telescope.builtin'.find_files{ theme = "dropdown" }`

Which doesn't exist currently.

--

This is how I am using it right now.

```
local opts = GetTheme("dropdown", { winblend = 3 })
require'telescope.builtin.find_files(opts)
```

Clip of it in action:
https://clips.twitch.tv/VictoriousYawningAnacondaWOOP

See #65 