### PR TITLE
use double dash to fix special filenames

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -115,7 +115,7 @@ builtin.live_grep = function(opts)
         return nil
       end
 
-      return flatten { conf.vimgrep_arguments, prompt }
+      return flatten { conf.vimgrep_arguments, " --", prompt }
     end,
     opts.entry_maker or make_entry.gen_from_vimgrep(opts),
     opts.max_results or 1000
@@ -346,7 +346,7 @@ builtin.grep_string = function(opts)
   pickers.new(opts, {
     prompt = 'Find Word',
     finder = finders.new_oneshot_job(
-      flatten { conf.vimgrep_arguments, search},
+      flatten { conf.vimgrep_arguments, " --", search},
       opts
     ),
     previewer = previewers.vimgrep.new(opts),

--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -193,9 +193,9 @@ end, {})
 previewers.cat = defaulter(function(opts)
   return previewers.new {
     setup = function()
-      local command_string = "cat '%s'"
+      local command_string = "cat -- '%s'"
       if 1 == vim.fn.executable("bat") then
-        command_string = "bat '%s' " .. bat_options
+        command_string = "bat " .. bat_options .. " -- '%s'"
       end
 
       return {
@@ -255,9 +255,9 @@ end, {})
 previewers.vimgrep = defaulter(function(_)
   return previewers.new {
     setup = function()
-      local command_string = "cat '%s'"
+      local command_string = "cat -- '%s'"
       if vim.fn.executable("bat") then
-        command_string = "bat '%s' --highlight-line '%s' -r '%s':'%s'" .. bat_options
+        command_string = "bat --highlight-line '%s' -r '%s':'%s'" .. bat_options .. " -- '%s'"
       end
 
       return {
@@ -286,7 +286,7 @@ previewers.vimgrep = defaulter(function(_)
 
       vim.api.nvim_win_set_buf(status.preview_win, bufnr)
 
-      local termopen_command = string.format(self.state.command_string, filename, lnum, start, finish)
+      local termopen_command = string.format(self.state.command_string, lnum, start, finish, filename)
 
       with_preview_window(status, function()
         vim.fn.termopen(termopen_command)


### PR DESCRIPTION
fix issue #71 

Add double dash when calling underlying programs to prevent mixing of options and arguments.

This should fix all problems with filenames like '--my-file-with-strange-name'