### PR TITLE
Respect sp, vsp, tabe mappings for buffers builtin

### DIFF
--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -91,8 +91,12 @@ local function goto_file_selection(prompt_bufnr, command)
 
     -- TODO: Sometimes we open something with missing line numbers and stuff...
     if entry_bufnr then
-      a.nvim_win_set_buf(original_win_id, entry_bufnr)
-      vim.api.nvim_command("doautocmd filetypedetect BufRead " .. vim.fn.fnameescape(filename))
+      if command == "e" then
+        a.nvim_win_set_buf(original_win_id, entry_bufnr)
+        vim.api.nvim_command("doautocmd filetypedetect BufRead " .. vim.fn.fnameescape(filename))
+      else
+        vim.cmd(string.format(":%s #%d", command, entry_bufnr))
+      end
     else
       vim.cmd(string.format(":%s %s", command, filename))
 


### PR DESCRIPTION
Respect `sp`, `vsp` and `tabe` mappings.

Maybe just a hack. I have to think about this later again.