### PR TITLE
buffers(): Trim cwd from bufname if possible

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -181,6 +181,8 @@ end
 function make_entry.gen_from_buffer(opts)
   opts = opts or {}
 
+  local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
+
   local get_position = function(entry)
     local tabpage_wins = vim.api.nvim_tabpage_list_wins(0)
     for k, v in ipairs(tabpage_wins) do
@@ -207,6 +209,11 @@ function make_entry.gen_from_buffer(opts)
   return function(entry)
     local bufnr_str = tostring(entry)
     local bufname = vim.api.nvim_buf_get_name(entry)
+
+    -- if bufname is inside the cwd, trim that part of the string
+    if bufname:sub(1, #cwd) == cwd  then
+      bufname = bufname:sub(#cwd + 1, #bufname)
+    end
 
     local position = get_position(entry)
 


### PR DESCRIPTION
Before this change, when using the `buffers()` builtin, the full path of the buffer filename was always shown because the `vim.api.nvim_buf_get_name()` API function is used (and that function always returns the full path).

I don't know lua at all so this may be a very naive solution, but it worked for me :laughing: .