### PR TITLE
Fix issue with trimming path separator '/' for buffers()

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -212,7 +212,12 @@ function make_entry.gen_from_buffer(opts)
 
     -- if bufname is inside the cwd, trim that part of the string
     if bufname:sub(1, #cwd) == cwd  then
-      bufname = bufname:sub(#cwd + 1, #bufname)
+      local offset =  0
+      -- if  cwd does ends in '/', we need to take it off
+      if cwd:sub(#cwd, #cwd) ~= '/' then
+        offset = 1
+      end
+      bufname = bufname:sub(#cwd + 1 + offset, #bufname)
     end
 
     local position = get_position(entry)

--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -3,6 +3,7 @@ local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
 local utils = require('telescope.utils')
 
 local get_default = utils.get_default
+local os_sep = utils.get_separator()
 
 local make_entry = {}
 
@@ -213,8 +214,8 @@ function make_entry.gen_from_buffer(opts)
     -- if bufname is inside the cwd, trim that part of the string
     if bufname:sub(1, #cwd) == cwd  then
       local offset =  0
-      -- if  cwd does ends in '/', we need to take it off
-      if cwd:sub(#cwd, #cwd) ~= '/' then
+      -- if  cwd does ends in the os separator, we need to take it off
+      if cwd:sub(#cwd, #cwd) ~= os_sep then
         offset = 1
       end
       bufname = bufname:sub(#cwd + 1 + offset, #bufname)


### PR DESCRIPTION
Follow up of https://github.com/nvim-lua/telescope.nvim/pull/104 that introduced a bug in which if `vim.fn.getcwd()` returns a string with a trailing path separator `/`, it causes the bufname path to be wrongly trimmed (e.g. `$(pwd)/foo/bar -> /foo/bar` instead of `$(pwd)/foo/bar -> foo/bar`).

This patch just checks the cwd trailing char and applies an offset.

@tjdevries I'm noticing that so far working with paths in lua has been quite hacky which in turn makes the appearence of these bugs easier. Is there a proper way to work with paths?

I have looked at [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) , and more concretely at  [path.lua](https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/path.lua) which according to the projects README it's suppose to be the equivalent of python's pathlib. But from looking at that file, it's still far behind which leaves me for now with manual string handling.