### PR TITLE
Nil check for no preview window

### DIFF
--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -241,7 +241,7 @@ previewers.vim_buffer = defaulter(function(_)
     setup = function() return { last_set_bufnr = nil } end,
 
     teardown = function(self)
-      if self.state.last_set_bufnr then
+      if self.state and self.state.last_set_bufnr then
         vim.api.nvim_buf_clear_namespace(self.state.last_set_bufnr, previewer_ns, 0, -1)
       end
     end,


### PR DESCRIPTION
When the window is too narrow for a preview window - state is nil and causes the below error and doesn't allow the pop up window to close.

![screenshot-20200922-1600831275](https://user-images.githubusercontent.com/12770181/93963369-00f99880-fd2b-11ea-8a48-e3f2d4d5067a.png)

I added a simple nil check and this seems to work fine but please advise if something more involved is required