### PR TITLE
fix: refresh `bufnr` after executing edit command

### DIFF
--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -101,6 +101,7 @@ local function goto_file_selection(prompt_bufnr, command)
       local bufnr = vim.api.nvim_get_current_buf()
       if filename ~= vim.api.nvim_buf_get_name(bufnr) then
         vim.cmd(string.format(":%s %s", command, filename))
+        bufnr = vim.api.nvim_get_current_buf()
         a.nvim_buf_set_option(bufnr, "buflisted", true)
       end
 


### PR DESCRIPTION
Fixes problem mentioned in https://github.com/nvim-lua/telescope.nvim/pull/107#issuecomment-697346324