### PR TITLE
Strips CR from vimgrep output on Windows

### DIFF
--- a/lua/telescope/make_entry.lua
+++ b/lua/telescope/make_entry.lua
@@ -102,11 +102,18 @@ function make_entry.gen_from_vimgrep(opts)
     return display
   end
 
+  local on_windows = vim.fn.has('win32')
+
   return function(line)
     -- TODO: Consider waiting to do this string.find
     -- TODO: Is this the fastest way to get each of these?
     --         Or could we just walk the text and check for colons faster?
     local _, _, filename, lnum, col, text = string.find(line, [[([^:]+):(%d+):(%d+):(.*)]])
+
+    -- Avoid printing out carriage returns (^M)
+    if on_windows == 1 then
+      text = text:gsub('\r', "")
+    end
 
     local ok
     ok, lnum = pcall(tonumber, lnum)


### PR DESCRIPTION
Vimgrep output from `rg` on Windows contains CRLF endings which result in lines ending in `^M` in the picker window. This should strip carriage returns from all output lines, with the precondition that vim is running on Windows.