### PR TITLE
WIP: Changed git command to show all files inside project

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -54,7 +54,7 @@ builtin.git_files = function(opts)
   pickers.new(opts, {
     prompt    = 'Git File',
     finder    = finders.new_oneshot_job(
-      { "git", "ls-files", "-o", "--exclude-standard", "-c" },
+      { "git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD" },
       opts
     ),
     previewer = previewers.cat.new(opts),


### PR DESCRIPTION
The current git command only shows the git files inside the working directory, not for the complete project. This seems to be the same functionality as the find_files command, this change will show all the files inside the project.