### PR TITLE
Fix if-clause after latest changes

### DIFF
--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -94,7 +94,7 @@ local function goto_file_selection(prompt_bufnr, command)
 
     -- TODO: Sometimes we open something with missing line numbers and stuff...
     if entry_bufnr then
-      if command == "e" then
+      if command == "edit" then
         a.nvim_win_set_buf(original_win_id, entry_bufnr)
       else
         vim.cmd(string.format(":%s #%d", command, entry_bufnr))


### PR DESCRIPTION
After the lastest changes in 3592b1f, this if branch is no longer reachable.

3592b1f still works but now we run `:edit #bufnr`, rather than `nvim_win_set_buf`.
This would be a valid choice but then we should remove the if clause. 
Regardless I would still vote for `nvim_win_set_buf` because the `edit` is not necessary here.