### PR TITLE
fix: Pass --paging=always to bat

### DIFF
--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -16,7 +16,7 @@ local Previewer = {}
 Previewer.__index = Previewer
 
 -- TODO: Should play with these some more, ty @clason
-local bat_options = {"--style=plain", "--color=always"}
+local bat_options = {"--style=plain", "--color=always", "--paging=always"}
 local bat_maker = function(filename, lnum, start, finish)
   local command = {"bat"}
 


### PR DESCRIPTION
This gets rid of a slightly annoying difference between files that fit
in the preview pane and ones that don't: hitting the scroll-preview
mappings would complain about a closed stream. Always using the pager
ensures there's always a process at the other end, even if asking it
to scroll doesn't actually do anything.