### PR TITLE
fix: Results height configurable. Properly collapse on border = false

### DIFF
--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -41,6 +41,9 @@ function config.set_defaults(defaults)
   set("prompt_position", "bottom")
   set("preview_cutoff", 120)
 
+  set("results_height", 1)
+  set("results_width", 0.8)
+
   set("border", {})
   set("borderchars", { '─', '│', '─', '│', '╭', '╮', '╯', '╰'})
 

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -87,10 +87,13 @@ function Picker:new(opts)
       -- TODO: If it's a list, of length 2, then it's a range of min to max?
       height = get_default(opts.height, 0.8),
       width = get_default(opts.width, config.values.width),
-      get_preview_width = get_default(opts.preview_width, config.values.get_preview_width),
-      results_width = get_default(opts.results_width, 0.8),
-      winblend = get_default(opts.winblend, config.values.winblend),
 
+      get_preview_width = get_default(opts.preview_width, config.values.get_preview_width),
+
+      results_width = get_default(opts.results_width, 0.8),
+      results_height = get_default(opts.results_height, 1),
+
+      winblend = get_default(opts.winblend, config.values.winblend),
       prompt_position = get_default(opts.prompt_position, config.values.prompt_position),
 
       -- Border config

--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -123,7 +123,6 @@ end
     +--------------+
 
 
-
 --]]
 
 -- Check if there are any borders. Right now it's a little raw as
@@ -138,9 +137,11 @@ layout_strategies.center = function(self, columns, lines, prompt_title)
   local results = initial_options.results
   local prompt = initial_options.prompt
 
-  local max_results = 15
-  local width = resolve.resolve_width(self.window.width)(self, columns)
+  -- This sets the height/width for the whole layout
+  local height = resolve.resolve_height(self.window.results_height)(self, lines)
+  local width = resolve.resolve_width(self.window.results_width)(self, columns)
 
+  local max_results = (height > lines and lines or height)
   local max_width = (width > columns and columns or width)
 
   prompt.height = 1
@@ -157,7 +158,7 @@ layout_strategies.center = function(self, columns, lines, prompt_title)
   end
 
   prompt.line = (lines / 2) - ((max_results + (bs * 2)) / 2)
-  results.line = prompt.line + 2
+  results.line = prompt.line + 1 + (bs)
 
   preview.line = 1
   preview.height = math.floor(prompt.line - (2 + bs))

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -17,7 +17,8 @@ function themes.get_dropdown(opts)
     layout_strategy = "center",
     results_title = false,
     preview_title = "Preview",
-    width = 70,
+    results_width = 70,
+    results_height = 15,
     borderchars = {
       { '─', '│', '─', '│', '╭', '╮', '╯', '╰'},
       prompt = {"─", "│", " ", "│", "╭", "╮", "│", "│"},


### PR DESCRIPTION
`get_dropdown{ border = false, results_height = 5})` 

![2020-10-04-162137_4480x1440_scrot](https://user-images.githubusercontent.com/15027/95026213-c0204e80-065d-11eb-8192-0c6130adca50.png)
