### PR TITLE
fix: Use width not results_width

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -139,7 +139,7 @@ layout_strategies.center = function(self, columns, lines, prompt_title)
 
   -- This sets the height/width for the whole layout
   local height = resolve.resolve_height(self.window.results_height)(self, lines)
-  local width = resolve.resolve_width(self.window.results_width)(self, columns)
+  local width = resolve.resolve_width(self.window.width)(self, columns)
 
   local max_results = (height > lines and lines or height)
   local max_width = (width > columns and columns or width)

--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -17,7 +17,7 @@ function themes.get_dropdown(opts)
     layout_strategy = "center",
     results_title = false,
     preview_title = "Preview",
-    results_width = 70,
+    width = 70,
     results_height = 15,
     borderchars = {
       { '─', '│', '─', '│', '╭', '╮', '╯', '╰'},


### PR DESCRIPTION
width makes more sense in this case (also was previous behavior)