### PR TITLE
fix: preview_cutoff to always show on dropdown theme

### DIFF
--- a/lua/telescope/themes.lua
+++ b/lua/telescope/themes.lua
@@ -17,7 +17,8 @@ function themes.get_dropdown(opts)
     layout_strategy = "center",
     results_title = false,
     preview_title = "Preview",
-    width = 70,
+    preview_cutoff = 1, -- Preview should always show (unless previewer = false) 
+    width = 80,
     results_height = 15,
     borderchars = {
       { '─', '│', '─', '│', '╭', '╮', '╯', '╰'},


### PR DESCRIPTION
Preview should now work properly for the dropdown theme by default.