### PR TITLE
fix picking height as width

### DIFF
--- a/lua/telescope/pickers/layout_strategies.lua
+++ b/lua/telescope/pickers/layout_strategies.lua
@@ -140,9 +140,8 @@ layout_strategies.center = function(self, columns, lines)
   local prompt = initial_options.prompt
 
   -- This sets the height/width for the whole layout
-  local height = resolve.resolve_height(self.window.results_height)(self, columns, lines)
-  local width = resolve.resolve_width(self.window.width)(self, columns, lines)
-
+  local height = resolve.resolve_height(self.window.results_height)(self, lines)
+  local width = resolve.resolve_width(self.window.width)(self, columns)
   local max_results = (height > lines and lines or height)
   local max_width = (width > columns and columns or width)
 
@@ -216,7 +215,7 @@ layout_strategies.vertical = function(self, max_columns, max_lines)
 
   -- Height
   local height_padding = math.max(
-    1, 
+    1,
     resolve.resolve_height(layout_config.height_padding or 3)(self, max_columns, max_lines)
   )
   local picker_height = max_lines - 2 * height_padding


### PR DESCRIPTION
The problem Im trying to fix is the following: I set up a with of 120, but end up with a width of 43 (number of lines in my nvim window). By reading the code on `resolve.lua`, `resolve_width` is going to pick the minimum between `val` and the values passed to the function returned by `resolve_width`. In this case, it is going to select the min value between 120 (my desired width), 158 (number of cols) and 43 (number of lines), and therefore the width is set to 43.

Im not sure if the fix is correct though. The comments on `resolve.lua` seem to imply that its correct to pass `(col, lines)` so, if thats the case, then the fix should be changing the `_resolve_map` functions so that it picks the minimum between `val` and `lines` or `cols` (depending on what is resolving), but not the 3 of them