### PR TITLE
Use results_height and results_width from config

### DIFF
--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -102,8 +102,8 @@ function Picker:new(opts)
 
       get_preview_width = get_default(opts.preview_width, config.values.get_preview_width),
 
-      results_width = get_default(opts.results_width, 0.8),
-      results_height = get_default(opts.results_height, 1),
+      results_width = get_default(opts.results_width, config.values.results_width),
+      results_height = get_default(opts.results_height, config.values.results_height),
 
       winblend = get_default(opts.winblend, config.values.winblend),
       prompt_position = get_default(opts.prompt_position, config.values.prompt_position),


### PR DESCRIPTION
For this snippet of code:

```vim
lua <<EOF
require'telescope'.setup{
  defaults = require('telescope.themes').get_dropdown{}
}
EOF

nnoremap <leader><space> <cmd>lua require'telescope.builtin'.find_files{}<CR>
```

The results_height from `get_dropdown` was not applied to the `find_files` function.

This fix uses `results_height` and `results_width` from `config` as it has the same defaults.