### PR TITLE
Ensure git_files uses the git root directory as cwd

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -46,10 +46,14 @@ local builtin = {}
 builtin.git_files = function(opts)
   opts = opts or {}
 
-  opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
+  else
+    opts.cwd = utils.capture("git rev-parse --show-toplevel")
   end
+  -- By creating the entry maker after the cwd options,
+  -- we ensure the maker uses the cwd options when being created.
+  opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
 
   pickers.new(opts, {
     prompt_title = 'Git File',

--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -49,7 +49,8 @@ builtin.git_files = function(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   else
-    opts.cwd = utils.capture("git rev-parse --show-toplevel")
+    --- Find root of git directory and remove trailing newline characters
+    opts.cwd = string.gsub(vim.fn.system("git rev-parse --show-toplevel"), '[\n\r]+', '')
   end
   -- By creating the entry maker after the cwd options,
   -- we ensure the maker uses the cwd options when being created.

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -176,26 +176,6 @@ function utils.max_split(s, pattern, maxsplit)
   end
 
   return t
-
----
--- Retrieve stdout from shell command
---
-function utils.capture(cmd)
-    local handle = assert(io.popen(cmd, 'r'))
-    local output = assert(handle:read('*a'))
-    handle:close()
-
-    output = string.gsub(
-        string.gsub(
-            string.gsub(output, '^%s+', ''),
-            '%s+$',
-            ''
-        ),
-        '[\n\r]+',
-        ' '
-    )
-   return output
-
 end
 
 return utils

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -176,6 +176,26 @@ function utils.max_split(s, pattern, maxsplit)
   end
 
   return t
+
+---
+-- Retrieve stdout from shell command
+--
+function utils.capture(cmd)
+    local handle = assert(io.popen(cmd, 'r'))
+    local output = assert(handle:read('*a'))
+    handle:close()
+
+    output = string.gsub(
+        string.gsub(
+            string.gsub(output, '^%s+', ''),
+            '%s+$',
+            ''
+        ),
+        '[\n\r]+',
+        ' '
+    )
+   return output
+
 end
 
 return utils


### PR DESCRIPTION
This sets the cwd option of the git_files builtin to use the root of the
git directory when the cwd option doesn't already exist. When git lists
files, it is relative to the root of the git directory, rather than the
current working directory. This caused problems when using git_files in
a subdirectory of the git root (see #174).

This commit fixes the issue by always setting the cwd as the root of the
git directory. I feel there is probably a better solution to extracting shell output
than writing the utils.capture function, however that is the solution I could find.