### PR TITLE
Fix find_command for find_files when using find executable

### DIFF
--- a/lua/telescope/builtin.lua
+++ b/lua/telescope/builtin.lua
@@ -546,7 +546,7 @@ builtin.find_files = function(opts)
     elseif 1 == vim.fn.executable("rg") then
       find_command = { 'rg', '--files' }
     elseif 1 == vim.fn.executable("find") then
-      find_command = { 'find', '-type', 'f' }
+      find_command = { 'find', '.', '-type', 'f' }
     end
   end
 


### PR DESCRIPTION
Fix #193

The MacOs [manpage](https://www.unix.com/man-page/osx/1/find/) says that a path is expected. This is not expected on Linux because `find` assumes `.`, if no starting-point is specified ([Ref](https://man7.org/linux/man-pages/man1/find.1.html)).

I can't test it because i don't own a Mac, so it must be confirmed by the author of the original issue.