### PR TITLE
feat: Get BAT_THEME var from environment

### DIFF
--- a/lua/telescope/previewers.lua
+++ b/lua/telescope/previewers.lua
@@ -23,6 +23,7 @@ local has_less = (vim.fn.executable('less') == 1) and config.values.use_less
 
 local bat_maker = function(filename, lnum, start, finish)
   local command = {"bat"}
+  local theme = os.getenv("BAT_THEME")
 
   if lnum then
     table.insert(command, { "--highlight-line", lnum})
@@ -38,6 +39,10 @@ local bat_maker = function(filename, lnum, start, finish)
     if start and finish then
       table.insert(command, { "-r", string.format("%s:%s", start, finish) })
     end
+  end
+
+  if theme ~= nil then
+    table.insert(command, { "--theme", string.format("%s", theme) })
   end
 
   return flatten {


### PR DESCRIPTION
This PR checks the environment for a BAT_THEME variable and if present sets the `--theme` flag to the bat previewer command.

Related: #196
