### PR TITLE
Actions can now be summed up and center action

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,13 @@ local function test_action(prompt_bufnr)
   print("Action was attached with prompt_bufnr: ", prompt_bufnr)
   -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
 end
-
 ["<C-i>"] = test_action,
 
 -- If you want your function to run after another action you should define it as follows
-local test_action = setmetatable({}, vim.tbl_extend("force", {
-  __call = function(_, prompt_bufnr)
-    print("This function ran after another action")
-    -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
-  end }, actions._action_mt)
-)
+local test_action = actions._transform_action(function(prompt_bufnr)
+  print("This function ran after another action. Prompt_bufnr: " .. prompt_bufnr)
+  -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
+end)
 ["<C-i>"] = actions.goto_file_selection_split + test_action
 
 ```
@@ -218,12 +215,10 @@ A full example:
 local actions = require('telescope.actions')
 
 -- If you want your function to run after another action you should define it as follows
-local test_action = setmetatable({}, vim.tbl_extend("force", {
-  __call = function(_, prompt_bufnr)
-    print("This function ran after another action")
-    -- Put your function here. You can take inspiration from lua/telescope/actions.lua
-  end }, actions._action_mt)
-)
+local test_action = actions._transform_action(function(prompt_bufnr)
+  print("This function ran after another action. Prompt_bufnr: " .. prompt_bufnr)
+  -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
+end)
 
 require('telescope').setup {
   defaults = {
@@ -236,8 +231,6 @@ require('telescope').setup {
         ["<c-s>"] = actions.goto_file_selection_split,
 
         -- Add up multiple actions
-        -- Currently actions.center is not set,
-        -- so if you want to center you screen after opening a file you should do this
         ["<CR>"] = actions.goto_file_selection_edit + actions.center,
 
         -- You can perform as many actions in a row as you like

--- a/README.md
+++ b/README.md
@@ -184,23 +184,31 @@ To see the full list of mappings, check out `lua/telescope/mappings.lua` and the
 
 To override ALL of the default mappings, you can use the `default_mappings` key in the `setup` table.
 
-```
- To disable a keymap, put [map] = false
+```lua
+-- To disable a keymap, put [map] = false
+-- So, to not map "<C-n>", just put
+["<C-n>"] = false,
+-- Into your config.
 
-        So, to not map "<C-n>", just put 
+-- Otherwise, just set the mapping to the function that you want it to be.
+["<C-i>"] = actions.goto_file_selection_split,
 
-            ...,
-            ["<C-n>"] = false,
-            ...,
+-- You can also define your own functions, which then can be mapped to a key
+local function test_action(prompt_bufnr)
+  print("Action was attached with prompt_bufnr: ", prompt_bufnr)
+  -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
+end
 
-        Into your config.
+["<C-i>"] = test_action,
 
- Otherwise, just set the mapping to the function that you want it to be.
-
-            ...,
-            ["<C-i>"] = actions.goto_file_selection_split
-            ...,
-
+-- If you want your function to run after another action you should define it as follows
+local test_action = setmetatable({}, vim.tbl_extend("force", {
+  __call = function(_, prompt_bufnr)
+    print("This function ran after another action")
+    -- Enter your function logic here. You can take inspiration from lua/telescope/actions.lua
+  end }, actions._action_mt)
+)
+["<C-i>"] = actions.goto_file_selection_split + test_action
 
 ```
 
@@ -208,6 +216,14 @@ A full example:
 
 ```lua
 local actions = require('telescope.actions')
+
+-- If you want your function to run after another action you should define it as follows
+local test_action = setmetatable({}, vim.tbl_extend("force", {
+  __call = function(_, prompt_bufnr)
+    print("This function ran after another action")
+    -- Put your function here. You can take inspiration from lua/telescope/actions.lua
+  end }, actions._action_mt)
+)
 
 require('telescope').setup {
   defaults = {
@@ -218,6 +234,14 @@ require('telescope').setup {
 
         -- Create a new <c-s> mapping
         ["<c-s>"] = actions.goto_file_selection_split,
+
+        -- Add up multiple actions
+        -- Currently actions.center is not set,
+        -- so if you want to center you screen after opening a file you should do this
+        ["<CR>"] = actions.goto_file_selection_edit + actions.center,
+
+        -- You can perform as many actions in a row as you like
+        ["<CR>"] = actions.goto_file_selection_edit + actions.center + test_action,
       },
     },
   }
@@ -379,7 +403,7 @@ Use the telescope.
 
 ## Themes
 
-Common groups of settings can be setup to allow for themes. We have some built in themes but are looking for more cool options. 
+Common groups of settings can be setup to allow for themes. We have some built in themes but are looking for more cool options.
 
 ### Dropdown
 
@@ -395,7 +419,7 @@ Then you can put your configuration into `get_dropdown({})`
 nnoremap <Leader>f :lua require'telescope.builtin'.find_files(require('telescope.themes').get_dropdown({ winblend = 10 }))<cr>
 ```
 
-Themes should work with every `telescope.builtin` function.  
+Themes should work with every `telescope.builtin` function.
 
 If you wish to make theme, check out `lua/telescope/themes.lua`. If you need more features, make an issue :).
 

--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -12,6 +12,15 @@ local actions = setmetatable({}, {
   end
 })
 
+local action_mt = {
+  __add = function (lhs, rhs)
+    return setmetatable({}, { __call = function(_, ...)
+      lhs(...)
+      rhs(...)
+    end })
+  end
+}
+
 --- Get the current picker object for the prompt
 function actions.get_current_picker(prompt_bufnr)
   return state.get_status(prompt_bufnr).picker
@@ -51,7 +60,6 @@ end
 
 -- TODO: It seems sometimes we get bad styling.
 local function goto_file_selection(prompt_bufnr, command)
-  local picker = actions.get_current_picker(prompt_bufnr)
   local entry = actions.get_selected_entry(prompt_bufnr)
 
   if not entry then
@@ -90,7 +98,6 @@ local function goto_file_selection(prompt_bufnr, command)
       a.nvim_win_set_config(preview_win, {style = ''})
     end
 
-    local original_win_id = picker.original_win_id or 0
     local entry_bufnr = entry.bufnr
 
     actions.close(prompt_bufnr)
@@ -115,6 +122,10 @@ local function goto_file_selection(prompt_bufnr, command)
       end
     end
   end
+end
+
+function actions.center(_)
+  vim.cmd(':normal zz')
 end
 
 function actions.goto_file_selection_edit(prompt_bufnr)
@@ -184,5 +195,15 @@ actions.insert_value = function(prompt_bufnr)
 
   return entry.value
 end
+
+for k, v in pairs(actions) do
+  actions[k] = setmetatable({}, vim.tbl_extend("force", {
+    __call = function(_, ...)
+      return v(...)
+    end }, action_mt)
+  )
+end
+
+actions._action_mt = action_mt
 
 return actions

--- a/lua/telescope/actions.lua
+++ b/lua/telescope/actions.lua
@@ -222,7 +222,6 @@ for k, v in pairs(actions) do
   actions[k] = transform_action(v)
 end
 
-actions._action_mt = action_mt
 actions._transform_action = transform_action
 
 return actions

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -16,7 +16,7 @@ mappings.default_mappings = config.values.default_mappings or {
       ["<Down>"] = actions.move_selection_next,
       ["<Up>"] = actions.move_selection_previous,
 
-      ["<CR>"] = actions.goto_file_selection_edit,
+      ["<CR>"] = actions.goto_file_selection_edit + actions.center,
       ["<C-x>"] = actions.goto_file_selection_split,
       ["<C-v>"] = actions.goto_file_selection_vsplit,
       ["<C-t>"] = actions.goto_file_selection_tabedit,

--- a/lua/telescope/mappings.lua
+++ b/lua/telescope/mappings.lua
@@ -30,7 +30,7 @@ mappings.default_mappings = config.values.default_mappings or {
 
     n = {
       ["<esc>"] = actions.close,
-      ["<CR>"] = actions.goto_file_selection_edit,
+      ["<CR>"] = actions.goto_file_selection_edit + actions.center,
       ["<C-x>"] = actions.goto_file_selection_split,
       ["<C-v>"] = actions.goto_file_selection_vsplit,
       ["<C-t>"] = actions.goto_file_selection_tabedit,


### PR DESCRIPTION
Close #182

This PR enables adding up actions.
I have never overloaded operators in lua, so I'm not sure if this is what you had in mind.
I tested this with center.
So my test setup was i had a file open(middle of a big file so zz actually does something) with my cursor at the bottom of the screen. When i now run `live_grep` i was looking for a string which can be found at the top of the screen.
When I searched for a string outside the screen, it was already centered, even though actions.center was not set.

Missing:
- [x] Documentation
- [x] More actions (tab, sp, vsp) (I don't think we need more actions to be tables)
- [x] Remove preconfigured center (basically remove changes made in `lua/telescope/mappings.lua#L19`)
- [x] Make `action_mt` accessible outside of `actions.lua`