### PR TITLE
Fix selection_strategies row and follow

### DIFF
--- a/lua/telescope/entry_manager.lua
+++ b/lua/telescope/entry_manager.lua
@@ -53,7 +53,7 @@ function EntryManager:new(max_results, set_entry, info)
         local existing_entry = v.entry
 
         -- FIXME: This has the problem of assuming that display will not be the same for two different entries.
-        if existing_entry.display == entry.display then
+        if existing_entry == entry then
           return k
         end
       end
@@ -110,7 +110,7 @@ function EntryManager:insert(picker, index, entry)
   -- and then shift all the corresponding items one place.
   local next_entry, last_score
   repeat
-    self.info.inserted = self.info.inserted + 1 
+    self.info.inserted = self.info.inserted + 1
     next_entry = self.entry_state[index]
 
     self.set_entry(picker, index, entry.entry, entry.score)

--- a/lua/telescope/pickers.lua
+++ b/lua/telescope/pickers.lua
@@ -683,8 +683,14 @@ function Picker:set_selection(row)
   row = self:_handle_scroll_strategy(row)
 
   if not self:can_select_row(row) then
-    log.debug("Cannot select row:", row, self.manager:num_results(), self.max_results)
-    return
+    -- If the current selected row exceeds number of currently displayed
+    -- elements we have to reset it. Affectes sorting_strategy = 'row'.
+    if not self:can_select_row(self:get_selection_row()) then
+      row = self:get_row(self.manager:num_results())
+    else
+      log.debug("Cannot select row:", row, self.manager:num_results(), self.max_results)
+      return
+    end
   end
 
   -- local entry = self.manager:get_entry(self.max_results - row + 1)


### PR DESCRIPTION
Fixes the "wanky" behavior of 'row'. With that i mean, when i manually select entry 10 and than start typing and entry 10 is no longer available because only 8 elements are displayed, we will not have a selection and because of this
https://github.com/nvim-lua/telescope.nvim/blob/051aefdb8cea71294e6e62e8a4a1e051c48e4edd/lua/telescope/pickers.lua#L685-L688
we cant move the selection. So now it will stick to the last element when this happens.
I don't this we have to wrap `self:get_row(self.manager:num_results())` in `self:_handle_scroll_strategy`.

Fixes `follow` by changing `manager:find_entry`. I think we can even just compare elements, which would do a pointer comparison which is way faster than comparing with `ordinal`. I tested it and it works but let me know if you think it has some side effects i don't know about.