### PR TITLE
fix options bug when options is table type in lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,9 @@ Also you can use the `Telescope` command with options in vim command line. like
 :Telescope find_files
 " Command with options
 :Telescope find_files  prompt_prefix=🔍
-
+" If option is table type in lua code ,you can use `,` connect each command string eg:
+" find_command,vimgrep_arguments they are both table type. so config it in commandline like
+:Telecope find_files find_command=rg,--ignore,--hidden,--files prompt_prefix=🔍
 ```
 
 

--- a/plugin/telescope.vim
+++ b/plugin/telescope.vim
@@ -39,9 +39,15 @@ function! s:load_command(builtin,...) abort
   let opts = {}
 
   " range command args
+  " if arg in lua code is table type,we split command string by `,` to vimscript
+  " list type.
   for arg in a:000
     let opt = split(arg,'=')
-    let opts[opt[0]] = opt[1]
+    if opt[0] == 'find_command' || opt[0] == 'vimgrep_arguments'
+      let opts[opt[0]] = split(opt[1],',')
+    else
+      let opts[opt[0]] = opt[1]
+    endif
   endfor
 
   let telescope = v:lua.require('telescope.builtin')


### PR DESCRIPTION
like `find_command` it's a table type in lua ,so we should use a vimscript list type, now we can use `,` to connect each command string ,then split it by `,` and pass to lua code. eg:

```vim
:Telescope find_files find_command=rg,--ignore,--hidden,--files prompt_prefix=XXX
```